### PR TITLE
Bugfix: Queries for drives that are not present would be simply ignored.

### DIFF
--- a/drivespace/Program.cs
+++ b/drivespace/Program.cs
@@ -15,14 +15,22 @@ namespace drivespace
 
             foreach (var drive in args
                 .Select(arg => arg.ToUpperInvariant().Split('-'))
-                .Where(parts => (parts.Length == 2) && parts[0].Equals("DRIVE") && driveInfo.ContainsKey(parts[1] + ":\\"))
-                .Select(parts => driveInfo[parts[1] + ":\\"]))
+                .Where(parts => (parts.Length == 2) && parts[0].Equals("DRIVE"))
+                .Select(parts => parts[1] + ":\\"))
             {
-                // TOTALSPACE,FREESPACE,STATUS
-                Console.WriteLine(
-                    (drive.IsReady ? drive.TotalSize : 0L) + "," +
-                    (drive.IsReady ? drive.TotalFreeSpace : 0L) + "," +
-                    (drive.IsReady ? "READY" : "NOTREADY"));
+                DriveInfo drive_status = null;
+                if (driveInfo.TryGetValue(drive, out drive_status))
+                {
+                    // TOTALSPACE,FREESPACE,STATUS
+                    Console.WriteLine(
+                        (drive_status.IsReady ? drive_status.TotalSize : 0L) + "," +
+                        (drive_status.IsReady ? drive_status.TotalFreeSpace : 0L) + "," +
+                        (drive_status.IsReady ? "READY" : "NOTREADY"));
+                }
+                else
+                {
+                    Console.WriteLine("0,0,NOTFOUND");
+                }
             }
         }
     }


### PR DESCRIPTION
When I use the command line `drive-E` to check on a non-existed drive, I got nothing, not even _NOTFOUND_ status code.

So I changed a little bit of the code to make it work when querying a drive that is not present.
